### PR TITLE
Add CardDetails page with affiliate link

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -11,6 +11,7 @@ import TopNav from "./components/TopNav";
 import BottomNav from "./components/BottomNav";
 import Index from "./pages/Index";
 import Cards from "./pages/Cards";
+import CardDetails from "./pages/CardDetails";
 import NotFound from "./pages/NotFound";
 
 const queryClient = new QueryClient();
@@ -27,6 +28,7 @@ const App = () => (
                 <Routes>
                   <Route path="/" element={<Index />} />
                   <Route path="/cards" element={<Cards />} />
+                  <Route path="/cards/:id" element={<CardDetails />} />
                   {/* ADD ALL CUSTOM ROUTES ABOVE THE CATCH-ALL "*" ROUTE */}
                   <Route path="*" element={<NotFound />} />
                 </Routes>

--- a/src/components/ui/command.tsx
+++ b/src/components/ui/command.tsx
@@ -21,7 +21,7 @@ const Command = React.forwardRef<
 ))
 Command.displayName = CommandPrimitive.displayName
 
-interface CommandDialogProps extends DialogProps {}
+type CommandDialogProps = DialogProps
 
 const CommandDialog = ({ children, ...props }: CommandDialogProps) => {
   return (

--- a/src/components/ui/textarea.tsx
+++ b/src/components/ui/textarea.tsx
@@ -2,8 +2,7 @@ import * as React from "react"
 
 import { cn } from "@/lib/utils"
 
-export interface TextareaProps
-  extends React.TextareaHTMLAttributes<HTMLTextAreaElement> {}
+export type TextareaProps = React.TextareaHTMLAttributes<HTMLTextAreaElement>
 
 const Textarea = React.forwardRef<HTMLTextAreaElement, TextareaProps>(
   ({ className, ...props }, ref) => {

--- a/src/pages/CardDetails.tsx
+++ b/src/pages/CardDetails.tsx
@@ -1,0 +1,65 @@
+import React from 'react';
+import { useParams } from 'react-router-dom';
+import { useCardData } from '../contexts/CardDataContext';
+import { toast } from '../components/ui/use-toast';
+
+const CardDetails: React.FC = () => {
+  const { id } = useParams();
+  const { getCardById } = useCardData();
+  const card = id ? getCardById(id) : undefined;
+
+  if (!card) {
+    return (
+      <div className="min-h-screen flex items-center justify-center">
+        <p>Card not found.</p>
+      </div>
+    );
+  }
+
+  const handleCopyLink = () => {
+    const link = `https://example.com/ref/${card.id}`;
+    navigator.clipboard.writeText(link);
+    toast({ title: 'Affiliate link copied!' });
+  };
+
+  return (
+    <div className="min-h-screen bg-cg-bg pt-16 pb-20 md:pb-4">
+      <div className="max-w-xl mx-auto px-4">
+        <div className="bg-cg-card p-6 rounded-cg-lg shadow-cg-card">
+          <div className="w-full h-32 bg-gradient-to-br from-cg-violet to-purple-600 rounded-lg flex items-center justify-center mb-4">
+            <span className="text-white font-bold text-xl">
+              {card.name.split(' ')[0]}
+            </span>
+          </div>
+          <h2 className="font-heading font-semibold text-2xl mb-2">{card.name}</h2>
+          <p className="text-cg-muted mb-4">{card.tagline}</p>
+
+          <div className="mb-6">
+            <h3 className="font-semibold mb-2">Rewards</h3>
+            <ul className="list-disc list-inside text-sm space-y-1">
+              <li>Default: {card.rewardRates.default}%</li>
+              {card.rewardRates.online && (
+                <li>Online: {card.rewardRates.online}%</li>
+              )}
+              {card.rewardRates.travel && (
+                <li>Travel: {card.rewardRates.travel}%</li>
+              )}
+              {card.rewardRates.fuel && (
+                <li>Fuel: {card.rewardRates.fuel}%</li>
+              )}
+            </ul>
+          </div>
+
+          <button
+            onClick={handleCopyLink}
+            className="w-full bg-gradient-orange text-white py-3 rounded-lg font-semibold hover:shadow-lg transition-shadow"
+          >
+            Copy affiliate link
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default CardDetails;

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -1,5 +1,6 @@
 
 import type { Config } from "tailwindcss";
+import animate from "tailwindcss-animate";
 
 export default {
 	darkMode: ["class"],
@@ -139,5 +140,5 @@ export default {
 			}
 		}
 	},
-	plugins: [require("tailwindcss-animate")],
+        plugins: [animate],
 } satisfies Config;


### PR DESCRIPTION
## Summary
- add new `CardDetails` page to show card info and copy link button
- register `/cards/:id` route in `App.tsx`
- tweak lint errors in `command.tsx`, `textarea.tsx`, and `tailwind.config.ts`

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_685248b21b808320ab1562f4c4255be9