### PR TITLE
Add toast-based copy link feature

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -11,6 +11,7 @@ import TopNav from "./components/TopNav";
 import BottomNav from "./components/BottomNav";
 import Index from "./pages/Index";
 import Cards from "./pages/Cards";
+import CardDetail from "./pages/CardDetail";
 import NotFound from "./pages/NotFound";
 
 const queryClient = new QueryClient();
@@ -27,6 +28,7 @@ const App = () => (
                 <Routes>
                   <Route path="/" element={<Index />} />
                   <Route path="/cards" element={<Cards />} />
+                  <Route path="/cards/:id" element={<CardDetail />} />
                   {/* ADD ALL CUSTOM ROUTES ABOVE THE CATCH-ALL "*" ROUTE */}
                   <Route path="*" element={<NotFound />} />
                 </Routes>

--- a/src/components/CardItem.tsx
+++ b/src/components/CardItem.tsx
@@ -4,6 +4,7 @@ import { Card } from '../data/cards';
 import { useCollection } from '../contexts/CollectionContext';
 import { Heart } from 'lucide-react';
 import CardTag from './CardTag';
+import { useToast } from '../hooks/use-toast';
 
 interface CardItemProps {
   card: Card;
@@ -23,10 +24,12 @@ const CardItem: React.FC<CardItemProps> = ({ card, onClick }) => {
     }
   };
 
+  const { toast } = useToast();
+
   const handleCTAClick = (e: React.MouseEvent) => {
     e.stopPropagation();
-    // For demo purposes, just show an alert
-    alert(`Affiliate link for ${card.name} copied!`);
+    navigator.clipboard.writeText(`${window.location.origin}/cards/${card.id}`);
+    toast({ title: "Link copied!" });
   };
 
   return (

--- a/src/pages/CardDetail.tsx
+++ b/src/pages/CardDetail.tsx
@@ -1,0 +1,78 @@
+import React from 'react';
+import { useParams } from 'react-router-dom';
+import { useCardData } from '../contexts/CardDataContext';
+import { useToast } from '../hooks/use-toast';
+import { useCollection } from '../contexts/CollectionContext';
+import { Heart } from 'lucide-react';
+import CardTag from '../components/CardTag';
+
+const CardDetail: React.FC = () => {
+  const { id } = useParams<{ id: string }>();
+  const { getCardById } = useCardData();
+  const card = id ? getCardById(id) : undefined;
+  const { isInCollection, addToCollection, removeFromCollection } = useCollection();
+  const { toast } = useToast();
+
+  if (!card) {
+    return <div className="p-4">Card not found</div>;
+  }
+
+  const inCollection = isInCollection(card.id);
+
+  const handleCopyLink = () => {
+    navigator.clipboard.writeText(`${window.location.origin}/cards/${card.id}`);
+    toast({ title: 'Link copied!' });
+  };
+
+  const handleCollectionToggle = () => {
+    if (inCollection) {
+      removeFromCollection(card.id);
+    } else {
+      addToCollection(card.id);
+    }
+  };
+
+  return (
+    <div className="min-h-screen bg-cg-bg pt-16 pb-20 md:pb-4">
+      <div className="max-w-2xl mx-auto px-4 animate-fade-in">
+        <div className="flex items-start gap-4 mb-6">
+          <div className="w-20 h-12 bg-gradient-to-br from-cg-violet to-purple-600 rounded-lg flex items-center justify-center">
+            <span className="text-white font-bold text-sm">{card.name.split(' ')[0]}</span>
+          </div>
+          <div className="flex-1">
+            <h1 className="font-heading font-bold text-2xl mb-1">{card.name}</h1>
+            <p className="text-cg-muted mb-2">{card.tagline}</p>
+            <CardTag card={card} />
+          </div>
+          <button
+            onClick={handleCollectionToggle}
+            className="p-2 hover:bg-gray-100 rounded-full transition-colors"
+            aria-label={`${inCollection ? 'Remove from' : 'Add to'} collection`}
+          >
+            <Heart className={`w-5 h-5 ${inCollection ? 'fill-red-500 text-red-500' : 'text-gray-400'}`} />
+          </button>
+        </div>
+
+        <div className="mb-8">
+          <h2 className="font-heading font-semibold text-lg mb-2">Details</h2>
+          <ul className="text-sm text-cg-dark list-disc ml-5 space-y-1">
+            <li>Annual fee: ₹{card.annualFee}</li>
+            <li>Lounge access: {card.loungeAccess}</li>
+            <li>Welcome bonus: {card.welcomeBonus}</li>
+          </ul>
+        </div>
+
+        <div className="pt-4 border-t border-gray-100">
+          <button
+            onClick={handleCopyLink}
+            className="w-full bg-gradient-orange text-white py-2 px-4 rounded-lg font-semibold text-sm hover:shadow-lg transition-shadow"
+          >
+            Copy Referral Link
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default CardDetail;


### PR DESCRIPTION
## Summary
- enable link copy feedback in `CardItem`
- add a new card detail page using the same toast UX
- register card detail page route

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_685248b5468c8320bbc7f92b3c1d43b4