### PR TITLE
Add dark mode toggle

### DIFF
--- a/index.html
+++ b/index.html
@@ -22,6 +22,12 @@
   </head>
 
   <body>
+    <script>
+      const storedTheme = localStorage.getItem('theme');
+      if (storedTheme === 'dark') {
+        document.body.classList.add('dark');
+      }
+    </script>
     <div id="root"></div>
     <script type="module" src="/src/main.tsx"></script>
   </body>

--- a/src/components/TopNav.tsx
+++ b/src/components/TopNav.tsx
@@ -1,7 +1,7 @@
 
-import React from 'react';
+import React, { useEffect, useState } from 'react';
 import { useCollection } from '../contexts/CollectionContext';
-import { Heart } from 'lucide-react';
+import { Heart, Moon, Sun } from 'lucide-react';
 
 interface TopNavProps {
   onCollectionClick?: () => void;
@@ -9,6 +9,19 @@ interface TopNavProps {
 
 const TopNav: React.FC<TopNavProps> = ({ onCollectionClick }) => {
   const { collectionCount } = useCollection();
+  const [darkMode, setDarkMode] = useState(() => {
+    if (typeof window !== 'undefined') {
+      return localStorage.getItem('theme') === 'dark';
+    }
+    return false;
+  });
+
+  useEffect(() => {
+    document.body.classList.toggle('dark', darkMode);
+    localStorage.setItem('theme', darkMode ? 'dark' : 'light');
+  }, [darkMode]);
+
+  const toggleTheme = () => setDarkMode((prev) => !prev);
 
   return (
     <nav className="fixed top-0 left-0 right-0 z-50 h-14 bg-gradient-violet text-white flex items-center justify-between px-4">
@@ -18,19 +31,29 @@ const TopNav: React.FC<TopNavProps> = ({ onCollectionClick }) => {
         </div>
         <span className="ml-2 font-heading font-semibold">CardGenius</span>
       </div>
-      
-      <button
-        onClick={onCollectionClick}
-        className="relative p-2 hover:bg-white/10 rounded-full transition-colors"
-        aria-label="Open collection"
-      >
-        <Heart className="w-5 h-5" />
-        {collectionCount > 0 && (
-          <span className="absolute -top-1 -right-1 bg-cg-orange text-white text-xs w-5 h-5 rounded-full flex items-center justify-center font-bold">
-            {collectionCount}
-          </span>
-        )}
-      </button>
+
+      <div className="flex items-center gap-2">
+        <button
+          onClick={toggleTheme}
+          className="p-2 hover:bg-white/10 rounded-full transition-colors"
+          aria-label="Toggle dark mode"
+        >
+          {darkMode ? <Sun className="w-5 h-5" /> : <Moon className="w-5 h-5" />}
+        </button>
+
+        <button
+          onClick={onCollectionClick}
+          className="relative p-2 hover:bg-white/10 rounded-full transition-colors"
+          aria-label="Open collection"
+        >
+          <Heart className="w-5 h-5" />
+          {collectionCount > 0 && (
+            <span className="absolute -top-1 -right-1 bg-cg-orange text-white text-xs w-5 h-5 rounded-full flex items-center justify-center font-bold">
+              {collectionCount}
+            </span>
+          )}
+        </button>
+      </div>
     </nav>
   );
 };


### PR DESCRIPTION
## Summary
- add theme persistence and toggle button in `TopNav`
- apply stored theme on page load via script

## Testing
- `npm run lint` *(fails: `no-require-imports` and other pre-existing issues)*
- `npm run build:dev`

------
https://chatgpt.com/codex/tasks/task_e_685248b760a8832093d93da75624bde0