### PR TITLE
Add Plausible analytics

### DIFF
--- a/index.html
+++ b/index.html
@@ -19,6 +19,7 @@
     <meta name="twitter:card" content="summary_large_image" />
     <meta name="twitter:site" content="@lovable_dev" />
     <meta name="twitter:image" content="https://lovable.dev/opengraph-image-p98pqg.png" />
+    <script defer data-domain="example.com" src="https://plausible.io/js/script.js"></script>
   </head>
 
   <body>

--- a/src/components/CardItem.tsx
+++ b/src/components/CardItem.tsx
@@ -25,14 +25,24 @@ const CardItem: React.FC<CardItemProps> = ({ card, onClick }) => {
 
   const handleCTAClick = (e: React.MouseEvent) => {
     e.stopPropagation();
+    window.plausible?.('Affiliate Link Copied', {
+      props: { cardName: card.name },
+    });
     // For demo purposes, just show an alert
     alert(`Affiliate link for ${card.name} copied!`);
   };
 
+  const handleCardClick = () => {
+    window.plausible?.('Card Click', {
+      props: { cardName: card.name },
+    });
+    onClick?.();
+  };
+
   return (
-    <div 
+    <div
       className="bg-cg-card p-4 rounded-cg-md shadow-cg-card cursor-pointer hover:shadow-lg transition-shadow animate-fade-in"
-      onClick={onClick}
+      onClick={handleCardClick}
     >
       <div className="flex gap-3">
         {/* Card Image */}

--- a/src/components/ui/command.tsx
+++ b/src/components/ui/command.tsx
@@ -21,7 +21,7 @@ const Command = React.forwardRef<
 ))
 Command.displayName = CommandPrimitive.displayName
 
-interface CommandDialogProps extends DialogProps {}
+type CommandDialogProps = DialogProps
 
 const CommandDialog = ({ children, ...props }: CommandDialogProps) => {
   return (

--- a/src/components/ui/textarea.tsx
+++ b/src/components/ui/textarea.tsx
@@ -2,8 +2,8 @@ import * as React from "react"
 
 import { cn } from "@/lib/utils"
 
-export interface TextareaProps
-  extends React.TextareaHTMLAttributes<HTMLTextAreaElement> {}
+export type TextareaProps =
+  React.TextareaHTMLAttributes<HTMLTextAreaElement>
 
 const Textarea = React.forwardRef<HTMLTextAreaElement, TextareaProps>(
   ({ className, ...props }, ref) => {

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -68,7 +68,14 @@ const Index = () => {
           <div className="grid md:grid-cols-2 lg:grid-cols-4 gap-6">
             {topCards.map((card) => (
               <div key={card.id} className="transform hover:scale-105 transition-transform">
-                <Link to={`/cards/${card.id}`}>
+                <Link
+                  to={`/cards/${card.id}`}
+                  onClick={() =>
+                    window.plausible?.('Card Click', {
+                      props: { cardName: card.name },
+                    })
+                  }
+                >
                   <div className="bg-cg-card p-4 rounded-cg-lg shadow-cg-card">
                     <div className="w-full h-24 bg-gradient-to-br from-cg-violet to-purple-600 rounded-lg mb-3 flex items-center justify-center">
                       <span className="text-white font-bold">{card.name.split(' ')[0]}</span>

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -1,1 +1,10 @@
 /// <reference types="vite/client" />
+
+interface Plausible {
+  (event: string, options?: { props?: Record<string, unknown> }): void;
+}
+
+interface Window {
+  plausible?: Plausible;
+}
+

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -1,5 +1,6 @@
 
 import type { Config } from "tailwindcss";
+import animate from "tailwindcss-animate";
 
 export default {
 	darkMode: ["class"],
@@ -139,5 +140,5 @@ export default {
 			}
 		}
 	},
-	plugins: [require("tailwindcss-animate")],
+        plugins: [animate],
 } satisfies Config;


### PR DESCRIPTION
## Summary
- integrate Plausible analytics
- track card clicks and affiliate link copies
- fix lint errors in command and textarea components
- switch Tailwind plugin to ES module import

## Testing
- `npm run lint`
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_685248b97be483208a6862b99f49073d