### PR TITLE
Add card images and skeleton loading

### DIFF
--- a/public/img/flipkart.svg
+++ b/public/img/flipkart.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="64" height="40">
+  <rect width="64" height="40" fill="#FFA500"/>
+  <text x="50%" y="50%" dominant-baseline="middle" text-anchor="middle" font-size="14" fill="white" font-family="Arial" font-weight="bold">Flipkart</text>
+</svg>

--- a/public/img/magnus.svg
+++ b/public/img/magnus.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="64" height="40">
+  <rect width="64" height="40" fill="#8A2BE2"/>
+  <text x="50%" y="50%" dominant-baseline="middle" text-anchor="middle" font-size="14" fill="white" font-family="Arial" font-weight="bold">Magnus</text>
+</svg>

--- a/public/img/millennia.svg
+++ b/public/img/millennia.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="64" height="40">
+  <rect width="64" height="40" fill="#0057e7"/>
+  <text x="50%" y="50%" dominant-baseline="middle" text-anchor="middle" font-size="14" fill="white" font-family="Arial" font-weight="bold">Millennia</text>
+</svg>

--- a/public/img/sbi.svg
+++ b/public/img/sbi.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="64" height="40">
+  <rect width="64" height="40" fill="#1c64f2"/>
+  <text x="50%" y="50%" dominant-baseline="middle" text-anchor="middle" font-size="14" fill="white" font-family="Arial" font-weight="bold">SBI</text>
+</svg>

--- a/public/img/wow.svg
+++ b/public/img/wow.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="64" height="40">
+  <rect width="64" height="40" fill="#008080"/>
+  <text x="50%" y="50%" dominant-baseline="middle" text-anchor="middle" font-size="14" fill="white" font-family="Arial" font-weight="bold">WOW</text>
+</svg>

--- a/src/components/CardItem.tsx
+++ b/src/components/CardItem.tsx
@@ -4,6 +4,7 @@ import { Card } from '../data/cards';
 import { useCollection } from '../contexts/CollectionContext';
 import { Heart } from 'lucide-react';
 import CardTag from './CardTag';
+import { Skeleton } from './ui/skeleton';
 
 interface CardItemProps {
   card: Card;
@@ -13,6 +14,7 @@ interface CardItemProps {
 const CardItem: React.FC<CardItemProps> = ({ card, onClick }) => {
   const { isInCollection, addToCollection, removeFromCollection } = useCollection();
   const inCollection = isInCollection(card.id);
+  const [imgLoaded, setImgLoaded] = React.useState(false);
 
   const handleCollectionToggle = (e: React.MouseEvent) => {
     e.stopPropagation();
@@ -30,14 +32,22 @@ const CardItem: React.FC<CardItemProps> = ({ card, onClick }) => {
   };
 
   return (
-    <div 
-      className="bg-cg-card p-4 rounded-cg-md shadow-cg-card cursor-pointer hover:shadow-lg transition-shadow animate-fade-in"
+    <div
+      className="bg-cg-card p-4 rounded-cg-md shadow-cg-card cursor-pointer hover:shadow-lg transition-shadow transform transition-transform hover:scale-105 hover:opacity-95 animate-fade-in"
       onClick={onClick}
     >
       <div className="flex gap-3">
         {/* Card Image */}
-        <div className="w-16 h-10 bg-gradient-to-br from-cg-violet to-purple-600 rounded-lg flex-shrink-0 flex items-center justify-center">
-          <span className="text-white font-bold text-xs">{card.name.split(' ')[0]}</span>
+        <div className="relative w-16 h-10 flex-shrink-0">
+          {!imgLoaded && (
+            <Skeleton className="absolute inset-0 w-full h-full rounded-lg" />
+          )}
+          <img
+            src={card.image}
+            alt={`${card.name} logo`}
+            className={`w-16 h-10 object-contain rounded-lg bg-white transition-opacity ${imgLoaded ? 'opacity-100' : 'opacity-0'}`}
+            onLoad={() => setImgLoaded(true)}
+          />
         </div>
 
         {/* Card Info */}

--- a/src/data/cards.ts
+++ b/src/data/cards.ts
@@ -22,7 +22,7 @@ export const cards: Card[] = [
   {
     id: "axis-magnus",
     name: "Axis Magnus",
-    image: "/img/magnus.png",
+    image: "/img/magnus.svg",
     tagline: "Unlimited lounges · High points",
     annualFee: 10000,
     isLifetimeFree: false,
@@ -35,7 +35,7 @@ export const cards: Card[] = [
   {
     id: "hdfc-millennia",
     name: "HDFC Millennia",
-    image: "/img/millennia.png",
+    image: "/img/millennia.svg",
     tagline: "E-commerce queen · 5% cashback",
     annualFee: 1000,
     isLifetimeFree: false,
@@ -48,7 +48,7 @@ export const cards: Card[] = [
   {
     id: "sbi-cashback",
     name: "SBI Cashback",
-    image: "/img/sbi.png",
+    image: "/img/sbi.svg",
     tagline: "Flat 5% online · ₹0 fee*",
     annualFee: 0,
     isLifetimeFree: true,
@@ -61,7 +61,7 @@ export const cards: Card[] = [
   {
     id: "axis-flipkart",
     name: "Axis Flipkart",
-    image: "/img/flipkart.png",
+    image: "/img/flipkart.svg",
     tagline: "Unlimited cashback king",
     annualFee: 500,
     isLifetimeFree: false,
@@ -74,7 +74,7 @@ export const cards: Card[] = [
   {
     id: "idfc-wow",
     name: "IDFC WOW",
-    image: "/img/wow.png",
+    image: "/img/wow.svg",
     tagline: "100% digital · ₹0 fee · rent OK",
     annualFee: 0,
     isLifetimeFree: true,


### PR DESCRIPTION
## Summary
- show logo images instead of gradient blocks
- tweak card hover states
- update card image paths
- include placeholder logos
- load card logos with a Skeleton until ready

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_685248b897488320b70e2e5f34a90402