### PR TITLE
Add sorting to cards list

### DIFF
--- a/src/contexts/FilterContext.tsx
+++ b/src/contexts/FilterContext.tsx
@@ -7,6 +7,7 @@ export interface FilterState {
   annualFeeRanges: string[];
   loungeAccess: string[];
   searchTerm: string;
+  sortOrder: "asc" | "desc";
 }
 
 interface FilterContextType {
@@ -20,7 +21,8 @@ const initialFilters: FilterState = {
   rentRewardsAllowed: false,
   annualFeeRanges: [],
   loungeAccess: [],
-  searchTerm: ''
+  searchTerm: '',
+  sortOrder: "asc"
 };
 
 const FilterContext = createContext<FilterContextType | undefined>(undefined);

--- a/src/pages/Cards.tsx
+++ b/src/pages/Cards.tsx
@@ -14,7 +14,7 @@ const Cards = () => {
   const [showFilters, setShowFilters] = useState(false);
 
   const filteredCards = useMemo(() => {
-    return cards.filter((card: Card) => {
+    const result = cards.filter((card: Card) => {
       // Search term filter
       if (filters.searchTerm) {
         const searchLower = filters.searchTerm.toLowerCase();
@@ -62,6 +62,12 @@ const Cards = () => {
 
       return true;
     });
+
+    return result.sort((a, b) =>
+      filters.sortOrder === "asc"
+        ? a.name.localeCompare(b.name)
+        : b.name.localeCompare(a.name)
+    );
   }, [cards, filters]);
 
   const handleCardClick = (card: Card) => {
@@ -110,7 +116,7 @@ const Cards = () => {
 
         <div className="flex gap-6">
           {/* Desktop Filters Sidebar */}
-          <div className="hidden md:block w-80 bg-cg-card rounded-lg p-6 shadow-cg-card h-fit">
+          <div className="hidden md:block w-80 bg-cg-card rounded-lg p-6 shadow-cg-card h-fit animate-slide-up">
             <div className="flex items-center justify-between mb-4">
               <h3 className="font-heading font-semibold text-lg">Filters</h3>
               <button
@@ -174,6 +180,21 @@ const Cards = () => {
                   <span>{access}</span>
                 </label>
               ))}
+            </div>
+
+            {/* Sort By */}
+            <div className="mb-6">
+              <h4 className="font-semibold mb-3">Sort By</h4>
+              <select
+                value={filters.sortOrder}
+                onChange={(e) =>
+                  updateFilters({ sortOrder: e.target.value as 'asc' | 'desc' })
+                }
+                className="w-full p-2 border rounded"
+              >
+                <option value="asc">Name A-Z</option>
+                <option value="desc">Name Z-A</option>
+              </select>
             </div>
           </div>
 
@@ -278,6 +299,21 @@ const Cards = () => {
                     <span>{access}</span>
                   </label>
                 ))}
+              </div>
+
+              {/* Sort By */}
+              <div>
+                <h4 className="font-semibold mb-3">Sort By</h4>
+                <select
+                  value={filters.sortOrder}
+                  onChange={(e) =>
+                    updateFilters({ sortOrder: e.target.value as 'asc' | 'desc' })
+                  }
+                  className="w-full p-2 border rounded"
+                >
+                  <option value="asc">Name A-Z</option>
+                  <option value="desc">Name Z-A</option>
+                </select>
               </div>
             </div>
 


### PR DESCRIPTION
## Summary
- add `sortOrder` in FilterContext
- provide sort controls in desktop and mobile filters
- sort cards in `useMemo`
- animate filter sidebar

## Testing
- `npm run lint` *(fails: `@typescript-eslint/no-empty-object-type` and `no-require-imports` errors)*

------
https://chatgpt.com/codex/tasks/task_e_685248b58614832080d6e80c5937c8be